### PR TITLE
Wrong substitution when dependencies are empty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ name := "gener8bundle"
 
 organization := "ohnosequences"
 
-version := "0.3.1"
+version := "0.3.2"
 
 scalaVersion := "2.9.1"
 

--- a/src/main/conscript/gener8bundle/launchconfig
+++ b/src/main/conscript/gener8bundle/launchconfig
@@ -1,5 +1,5 @@
 [app]
-  version: 0.3.1
+  version: 0.3.2
   org: ohnosequences
   name: gener8bundle
   class: ohnosequences.statica.gener8bundle.App

--- a/src/main/scala/gener8bundle.scala
+++ b/src/main/scala/gener8bundle.scala
@@ -38,11 +38,9 @@ case class BundleDescription(
      opt("description", description) ++
      opt("org", org) ++
      opt("scala_version", scala_version) ++
-      ( if (dependencies.isEmpty) Seq()
-        else Seq(("depsSbt", depsSbt(dependencies)),
-                 ("depsImport", depsImport(dependencies)),
-                 ("depsHList", depsHList(dependencies)))
-      )
+     Seq( ("depsSbt", depsSbt(dependencies)),
+          ("depsImport", depsImport(dependencies)),
+          ("depsHList", depsHList(dependencies)))
     ) map {case (k,v) => format(k,v)}
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
 
-version in ThisBuild := "0.3.1"
+version in ThisBuild := "0.3.2"


### PR DESCRIPTION
The result was like this:

``` scala
object Foo extends Bundle(
      name = "Foo",
      version = "0.1.0",
    ) { ...
```

(third argument of `Bundle` is empty)
